### PR TITLE
#162162972  Article tags should be present in all relevant views

### DIFF
--- a/src/components/articles/taggedArticles/__tests__/pageHeaderTest.jsx
+++ b/src/components/articles/taggedArticles/__tests__/pageHeaderTest.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import TagHeader from '../pageHeaderComponent';
+
+describe('tag header component', () => {
+  const props = {
+    tagName: 'tech',
+  };
+
+  it('renders with tag name', () => {
+    const wrapper = shallow(<TagHeader {...props} />);
+    const tagName = wrapper.find('.blog-header');
+    expect(tagName).toBeTruthy();
+  });
+});

--- a/src/components/articles/taggedArticles/pageHeaderComponent.jsx
+++ b/src/components/articles/taggedArticles/pageHeaderComponent.jsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import './tag-view.scss';
+import PropTypes from 'prop-types';
+
+
+const TagHeader = ({ tagName }) => {
+  return (
+    <div className="container">
+      <div className="blog-header py-3">
+        <h3>{ tagName }</h3>
+      </div>
+      <div className="py-3">
+        <h4>Articles:</h4>
+      </div>
+    </div>
+  );
+};
+
+TagHeader.propTypes = {
+  tagName: PropTypes.string.isRequired,
+};
+
+export default TagHeader;

--- a/src/components/articles/taggedArticles/tag-view.scss
+++ b/src/components/articles/taggedArticles/tag-view.scss
@@ -1,0 +1,9 @@
+.blog-header {
+  border: {
+    bottom: 2px solid#A9A9A9;
+  }
+}
+
+.py-3 {
+  padding-bottom: 1rem;
+}

--- a/src/components/dashboard/Dashboard.scss
+++ b/src/components/dashboard/Dashboard.scss
@@ -89,3 +89,10 @@ p {
 div.article-row { 
     padding: 6px;
 }
+
+.badge-info {
+  margin: {
+    right: 5px;
+  }
+  cursor: pointer;
+}

--- a/src/components/dashboard/HomeComponent.jsx
+++ b/src/components/dashboard/HomeComponent.jsx
@@ -5,19 +5,32 @@ import SideBar from './SideBarComponent';
 import Article from './ArticleComponent';
 import './Dashboard.scss';
 import '../articles/articles.scss';
+import TagHeader from '../articles/taggedArticles/pageHeaderComponent';
 
 
 class Home extends React.Component {
   render() {
-    const { articles, getArticle } = this.props;
+    const {
+      articles, getArticle, getTaggedArticles, tagView, tagName,
+    } = this.props;
     const articleList = articles || [];
-    return (
+    if (tagView) {
+      return (
+        <div className="container-fluid">
+          <div className="row">
+            <TagHeader tagName={tagName}/>
+            <div className="col-lg-10 col-md-10 article-content">
+              {articleList.map(article => (<Article getArticle={getArticle} article={article} key={article.id} />))}
+            </div>
+          </div>
+        </div>
+      );
+    } return (
       <div className="container-fluid">
         <div className="row">
-          <SideBar articles={articleList} />
+          <SideBar articles={articleList} getTaggedArticles={getTaggedArticles}/>
           <div className="col-lg-10 col-md-10 article-content">
-            {articleList.map(article => (
-              <Article getArticle={getArticle} article={article} key={article.id} />))}
+            {articleList.map(article => (<Article getArticle={getArticle} article={article} key={article.id} />))}
           </div>
         </div>
       </div>
@@ -43,6 +56,9 @@ Home.propTypes = {
     }),
   ),
   getArticle: PropTypes.func.isRequired,
+  getTaggedArticles: PropTypes.func.isRequired,
+  tagView: PropTypes.bool.isRequired,
+  tagName: PropTypes.string.isRequired,
 };
 
 Home.defaultProps = {

--- a/src/components/dashboard/SideBarComponent.jsx
+++ b/src/components/dashboard/SideBarComponent.jsx
@@ -14,6 +14,18 @@ class SideBar extends Component {
       </li>);
   };
 
+  renderTags = (article) => {
+    const { tags = [], id } = article;
+    const { getTaggedArticles } = this.props;
+    return (
+      <div className="nav-item" key={id}>
+        <div className="tag-item">
+          {tags.map((tag, i) =><a key={i}><span key={i} className="badge badge-info" id="tag-name" onClick={getTaggedArticles(tag)}>{tag}</span></a>)}
+        </div>
+      </div>
+    );
+  }
+
   render() {
     const { articles } = this.props;
     return (
@@ -22,6 +34,10 @@ class SideBar extends Component {
           <ul className="nav flex-column">
             { articles.map(article => (this.renderArticle(article))) }
           </ul>
+          <div>
+            <i className="fa fa-tags">Tags: </i>
+            {articles.map(article => (this.renderTags(article)))}
+          </div>
         </div>
       </nav>
     );
@@ -45,6 +61,7 @@ SideBar.propTypes = {
       id: PropTypes.number,
     }),
   ),
+  getTaggedArticles: PropTypes.func.isRequired,
 };
 
 SideBar.defaultProps = {

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -12,9 +12,7 @@ import HomeView from '../views/homeView/homeView';
 import { getDataThunk } from '../redux/thunks';
 import { getAllArticles } from '../redux/actions/ArticleActionCreators';
 
-
 export const store = configureStore();
-
 store.dispatch(getDataThunk('articles', getAllArticles));
 
 class Routes extends Component {

--- a/src/views/homeView/__tests__/homeViewTest.js
+++ b/src/views/homeView/__tests__/homeViewTest.js
@@ -1,5 +1,4 @@
 /* eslint-disable react/jsx-filename-extension */
-
 import React from 'react';
 import configureStore from 'redux-mock-store';
 import { mount } from 'enzyme';
@@ -19,7 +18,7 @@ const testClickButton = (wrapper, buttonId, mockMethod) => {
 
 const mockStore = configureStore([thunk]);
 
-const props = {
+let props = {
   actions: {
     getOneArticle: jest.fn(),
     getDataThunk: jest.fn(),
@@ -29,6 +28,8 @@ const props = {
   nextPage: '',
   prevPage: '',
   currentPage: 1,
+  tagView: false,
+  tagName: '',
 };
 describe('Home view test', () => {
   let wrapper;
@@ -66,5 +67,10 @@ describe('Home view test', () => {
     props.match = { params: { articleId: 'how-to-train-your-dragon' } };
     wrapper = mount(<Provider store={store}><HomeViewTest {...props} /></Provider>);
     jest.runAllTimers();
+  });
+
+  it('should handle click event on tag', () => {
+    wrapper.find('#tag-name').first().simulate('click');
+    expect(wrapper.find('#tag-name')).toBeDefined();
   });
 });

--- a/src/views/homeView/homeView.jsx
+++ b/src/views/homeView/homeView.jsx
@@ -4,24 +4,27 @@ import { bindActionCreators } from 'redux'
 import Home from '../../components/dashboard/HomeComponent';
 import NavBar from '../../components/dashboard/NavBarComponent';
 import Articles from '../../components/articles/Articles';
-import { requestArticle, getOneArticle, getAllArticles } from '../../redux/actions/ArticleActionCreators'
-import CircularProgressLoader from '../../components/progress/index'
+import { requestArticle, getOneArticle, getAllArticles } from '../../redux/actions/ArticleActionCreators';
+import CircularProgressLoader from '../../components/progress/index';
 import { getDataThunk } from '../../redux/thunks';
+
 
 export class HomeView extends Component {
   state = {
     goToArticles: false,
     viewArticle: false,
+    tagView: false,
+    tagName: '',
     loader: {
       success: false,
-      loading: false
-    }
+      loading: false,
+    },
   }
 
   componentDidMount() {
-    const { match } = this.props
+    const { match } = this.props;
     if (match.params.articleId) {
-      const { articleId } = match.params
+      const { articleId } = match.params;
       this.props.actions.getDataThunk(`articles/${articleId}`, requestArticle)
       this.setState({ loader: { loading: true } });
       this.singleArticlePage(4000, true)
@@ -60,8 +63,18 @@ export class HomeView extends Component {
     this.setState({ loader: { loading: bool } })
   }
 
+  handleClick = tag => (e) => {
+    e.preventDefault();
+    const { actions: { getDataThunk } } = this.props;
+    getDataThunk('articles?tags='.concat(tag), getAllArticles);
+    this.setState({
+      tagView: true,
+      tagName: tag,
+    });
+  }
+
   render() {
-    const { viewArticle, goToArticles, loader } = this.state;
+    const { viewArticle, goToArticles, loader, tagView, tagName } = this.state;
     const { articles, nextPage, prevPage, currentPage } = this.props;
     return (
       <div>
@@ -74,7 +87,7 @@ export class HomeView extends Component {
             singleArticlePage={this.singleArticlePage} /> :
           <Home getArticle={this.getArticle} articles={articles}
             nextPage={nextPage}
-            prevPage={prevPage} currentPage={currentPage} />}
+            prevPage={prevPage} currentPage={currentPage} getTaggedArticles={this.handleClick} tagView={tagView} tagName={tagName}/>}
       </div>
     );
   }


### PR DESCRIPTION
**What does this PR do?**
Adds tag view functionality, such that when a user clicks on a certain tag, all the related articles are returned.

**Description of tasks to be completed?**
- Create tagged articles page component
- Create the body header component
- Create sass styling for body header
- Add tag view route to routes file.
- Integrate articles body.
- Create a container component for tagged articles.
- Add click functionality on tags.
- Have all tests written.

**How can this be manually tested?**
- Clone the repository by running git clone https://github.com/andela/ah-frontend-poseidon.git
- Run git checkout ft-tagged-article-view-162162972
- Start the server by running yarn start
- Navigate to the articles page, click on a tag, related articles will be displayed.

**Screenshots**
![image](https://user-images.githubusercontent.com/40595048/51752384-69acef80-20c8-11e9-9933-9fb24b08b277.png)
![image](https://user-images.githubusercontent.com/40595048/51752341-4da94e00-20c8-11e9-93cd-cc619511bf36.png)

**What are the related pivotal tracker stories?**
[#162162972]