### PR TITLE
 #162162970 Pagination support for articles

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,6 @@ import './App.scss';
 import fontawesome from '@fortawesome/fontawesome';
 import solid from '@fortawesome/fontawesome-free-solid';
 import regular from '@fortawesome/fontawesome-free-regular';
-
 import '../node_modules/bootstrap/dist/css/bootstrap.min.css';
 import { library } from '@fortawesome/fontawesome-svg-core';
 import { faFacebook, faTwitter } from '@fortawesome/free-brands-svg-icons';

--- a/src/components/__tests__/homeComponent.test.js
+++ b/src/components/__tests__/homeComponent.test.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import HomeComponent from '../dashboard/HomeComponent';
+import mockArticles from '../dashboard/mockData';
+
+
+const homeProps = {
+  getArticle: jest.fn(),
+  articles: mockArticles,
+  nextPage: 'https://ah-backend-poseidon-staging.herokuapp.com/api/articles?page=2',
+  prevPage: 'https://ah-backend-poseidon-staging.herokuapp.com/api/articles?page=2',
+  currentPage: 1,
+  getArticlesPage: jest.fn(),
+  getTaggedArticles: jest.fn(),
+  tagView: false,
+  tagName: '',
+};
+
+describe('Home component', () => {
+  const pageButtons = ['#nextPage', '#prevPage'];
+
+  pageButtons.forEach(button => (
+    it('getArticlesPage prop should be called on pagination button click', () => {
+      const wrapper = mount(<HomeComponent {...homeProps} />);
+      const spy = jest.spyOn(wrapper.instance().props, 'getArticlesPage');
+      wrapper.find(button).simulate('click');
+      expect(spy).toBeCalled();
+    })
+  ));
+});

--- a/src/components/articles/ArticlePage.jsx
+++ b/src/components/articles/ArticlePage.jsx
@@ -4,22 +4,21 @@ import PropTypes from 'prop-types';
 import fontawesome from '@fortawesome/fontawesome';
 import solid from '@fortawesome/fontawesome-free-solid';
 import regular from '@fortawesome/fontawesome-free-regular';
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import Tags from './Tags';
 import { editArticle } from '../../redux/actions/ArticleActionCreators';
 import { doNothing } from '../../redux/actions/commonActions';
 import ButtonGroup from '../socialShare/buttonGroup';
 import LikeDislikeView from '../../views/LikeDislikeView';
 import StarRatingSystem from '../../views/ratingSystemView';
-import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 
 fontawesome.library.add(solid, regular);
 
 const DateDisplay = dateString => new Date(dateString).toDateString();
-
 class Article extends Component {
   componentDidMount() {
     const {
-      article: { body }
+      article: { body },
     } = this.props;
     document.getElementById('data').innerHTML = body;
   }
@@ -28,11 +27,11 @@ class Article extends Component {
     const {
       article: {
         author: { image, username },
+        title,
         created_on,
-        image_url,
         read_time,
         slug,
-        title,
+        image_url,
         description,
         tags,
       },
@@ -42,108 +41,81 @@ class Article extends Component {
 
     return (
       <div className="container singleArticle">
-        <div className="row">
+        <div id="central">
           <div className="col-lg-8">
             <h1>{title}</h1>
             <div className="row">
-              <div className="col-md-1.5 img">
-                <img
-                  className="rounded-circle"
-                  src={image || 'http://placehold.it/300x300'}
-                />
-                <blockquote>
-                  <h6>{username}</h6>
-                  <i>{DateDisplay(created_on)}</i>
-                  <h6>{read_time}</h6>
-                </blockquote>
+              <div className="col-9 card-title mb-4">
+                <div className="d-flex justify-content-start">
+                  <div className="image-container">
+                    <img className="rounded-circle" src={image || 'http://placehold.it/70x70'} id="imgProfile" />
+                  </div>
+                  <div className="userData ml-3">
+                    <h3 className="d-block">{username}</h3>
+                    <h6 className="d-block">{DateDisplay(created_on)}</h6>
+                    <h6 className="d-block">{read_time}</h6>
+                  </div>
+                </div>
               </div>
-
-              <div
-                className="col-3"
-                hidden={username !== localStorage.getItem('username')}
-              >
+              <div className="col" hidden={username !== localStorage.getItem('username')}>
                 <button
-                  id="edit"
                   type="button"
-                  className="btn btn-primary"
+                  id="edit"
+                  className="btn btn-primary space"
                   onClick={onClickHandler(slug, null, editArticle, 'put')}
                   value="Edit"
-                >
-                  Edit
+                  >
+                Edit
                 </button>
                 <button
-                  id="del"
                   type="button"
+                  id="del"
                   className="btn btn-primary"
                   onClick={onClickHandler(slug, null, doNothing, 'delete')}
                   value="Delete"
-                >
-                  Delete
+                  >
+                Delete
                 </button>
               </div>
             </div>
             <hr />
-            <img
-              src={image_url || 'http://placehold.it/700x300'}
-              className="img-responsive article-img"
-            />
+            {image_url ? <img src={image_url} className="img-responsive article-img" /> : ''}
             <hr />
             <p className="lead">{description}</p>
             <div id="data" className="panel" />
             <br />
             <br />
-
             <Tags tags={tags} />
+            <br />
             <hr />
             <LikeDislikeView />
             <br />
-            {
-                  username !== localStorage.getItem('username')
-                    ? (
-                      <div className="card">
-                        <div className="card-header">
-                          <StarRatingSystem slug={slug} />
-                        </div>
-                      </div>
-                    )
-                    : ''
-              }
-            <hr />
+            {username !== localStorage.getItem('username') ? (
+              <div className="card">
+                <div className="card-header">
+                  <StarRatingSystem slug={slug} />
+                </div>
+              </div>
+            ) : (
+              ''
+            )}
             <div className="well">
               <h4>
                 <FontAwesomeIcon icon="paper-plane" />
                 {' '}
                 Leave a Comment:
               </h4>
-
               <ButtonGroup slug={slug} shareHandler={shareHandler} />
               <form>
                 <div className="form-group">
                   <textarea className="form-control" rows="3" />
                 </div>
-                <button className="btn btn-primary" type="submit">
-                  Comment
-                </button>
+                <button className="btn btn-primary" type="submit">Comment</button>
               </form>
-            </div>
-            <hr />
-            <div>
-              <h3>
-                <FontAwesomeIcon icon="comment" />
-                User One says:
-                <small> 9:41 PM on August 24, 2014</small>
-              </h3>
-              <p>Excellent post! Thank You the great article, it was useful!</p>
-
-              <h3>
-                <FontAwesomeIcon icon="comment" />
-                User Two says:
-                <small> 9:47 PM on August 24, 2014</small>
-              </h3>
-              <p>Excellent post! Thank You the great article, it was useful!</p>
             </div>
           </div>
         </div>
+        <hr />
       </div>
     );
   }

--- a/src/components/articles/Articles.jsx
+++ b/src/components/articles/Articles.jsx
@@ -1,14 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { bindActionCreators } from 'redux';
-import * as Actions from '../../redux/thunks';
-import {
-  createArticle,
-  getAllArticles,
-  getOneArticle,
-  deleteArticle,
-  shareArticle
-} from '../../redux/actions/ArticleActionCreators';
+import { createArticle, getAllArticles, shareArticle } from '../../redux/actions/ArticleActionCreators';
 import { CreateArticlePage, ArticlePage } from '.';
 import './articles.scss';
 
@@ -19,6 +11,7 @@ export class ArticleView extends React.Component {
       getTitle: '',
       getDescription: '',
       getTags: '',
+      getImage: null,
       contentArea: '',
       viewArticle: false,
       endpointOption: 'articles/',
@@ -33,32 +26,53 @@ export class ArticleView extends React.Component {
 
   handleChangeValue = param => e => this.setState({ [param]: e.target.value });
 
-  handleArticleBody = e => {
-    const newHTML = e.target.innerText.trim();
+  handleArticleBody = (e) => {
+    e.target.innerText.trim();
+    const newHTML = e.target.innerHTML;
     this.setState({ contentArea: newHTML });
   };
 
   handleCreate = (endpoint, actionCreator, method) => e => {
     e.preventDefault();
-    const { getTitle, getDescription, contentArea, getTags } = this.state;
+    const {
+ getTitle, getDescription, contentArea, getTags, getImage,
+} = this.state;
     const data = {
       article: {
         title: getTitle,
         description: getDescription,
         body: contentArea,
-        tags: getTags.split(',')
-      }
+        tags: getTags.split(','),
+        image_url: getImage,
+      },
     };
-    const { singleArticlePage, isLoading } = this.props;
-    this.props.actions.postDataThunk(endpoint, data, actionCreator, method);
+    const { singleArticlePage, isLoading, postDataThunk } = this.props;
+    postDataThunk(endpoint, data, actionCreator, method);
     isLoading(true);
     singleArticlePage(4000, true);
   };
 
-  handleDelete = (slug, data, action, method) => e => {
+  uploadImage = () => {
+    window.cloudinary.openUploadWidget(
+      {
+        cloud_name: 'dos4j4vpc',
+        upload_preset: 'hmpkjx6m',
+        folder: 'poseidon',
+        cropping: true,
+        sources: ['local', 'url', 'google_photos', 'facebook', 'image_search'],
+      },
+      (error, result) => {
+        this.setState({
+          getImage: result[0].secure_url,
+        });
+      },
+    );
+  }
+
+  handleDelete = (slug, data, action, method) => (e) => {
     e.preventDefault();
-    const { postDataThunk, deleteArticle, getDataThunk } = this.props.actions;
-    const { backToHome, isLoading } = this.props;
+    const { postDataThunk, deleteArticle, getDataThunk } = this.props;
+    const { backToHome, isLoading, singleArticlePage } = this.props;
     if (method === 'delete') {
       postDataThunk(`articles/${slug}`, data, action, method);
       isLoading(true);
@@ -72,7 +86,11 @@ export class ArticleView extends React.Component {
       }, 6000);
     }
     if (method === 'put') {
-      const { body, title, description, tags } = this.props.article;
+      const {
+        article: {
+          body, title, description, tags,
+        },
+      } = this.props;
       this.setState(prevState => ({
         endpointOption: `articles/${slug}/`,
         createAction: action,
@@ -82,7 +100,7 @@ export class ArticleView extends React.Component {
         getDescription: description,
         getTags: tags.toString()
       }));
-      this.props.singleArticlePage(0, false);
+      singleArticlePage(0, false);
     }
   };
 
@@ -90,57 +108,37 @@ export class ArticleView extends React.Component {
     e.preventDefault();
     const endpoint = `/${slug}/email`;
     const data = '';
-    const { actions } = this.props;
+    const { postDataThunk } = this.props;
     const { createMethod } = this.state;
-    actions.postDataThunk(endpoint, data, shareArticle, createMethod);
-  };
+    postDataThunk(endpoint, data, shareArticle, createMethod);
+  }
 
   render() {
+    const { viewArticle, article } = this.props;
+    const {
+      getTitle, getDescription, getTags, endpointOption, createAction, createMethod, contentArea,
+    } = this.state;
+    const createArticleProps = {
+      titleValue: getTitle,
+      descriptionValue: getDescription,
+      tagsValue: getTags,
+      handleCreate: this.handleCreate(endpointOption, createAction, createMethod),
+      handleChangeValue: this.handleChangeValue,
+      handleArticleBody: this.handleArticleBody,
+      imageUpload: this.uploadImage,
+      contentArea,
+    };
     return (
       <div className="container wrapperId">
-        {this.props.viewArticle ? (
-          <ArticlePage
-            article={this.props.article}
-            onClickHandler={this.handleDelete}
-            shareHandler={this.handleShare}
-          />
-        ) : (
-          <CreateArticlePage
-            titleValue={this.state.getTitle}
-            descriptionValue={this.state.getDescription}
-            tagsValue={this.state.getTags}
-            handleCreate={this.handleCreate(
-              this.state.endpointOption,
-              this.state.createAction,
-              this.state.createMethod
-            )}
-            handleChangeValue={this.handleChangeValue}
-            handleArticleBody={this.handleArticleBody}
-            contentArea={this.state.contentArea}
-          />
-        )}
+        {viewArticle ? <ArticlePage article={article} onClickHandler={this.handleDelete} shareHandler={this.handleShare} />
+          : <CreateArticlePage {...createArticleProps} />}
       </div>
     );
   }
 }
 
-const mapStateToProps = state => ({
-  article: state.articles.article
+const mapStateToProps = ({ articles: { article } }) => ({
+  article,
 });
 
-const mapDispatchToProps = dispatch => ({
-  actions: bindActionCreators(
-    {
-      ...Actions,
-      getOneArticle,
-      deleteArticle,
-      shareArticle
-    },
-    dispatch
-  )
-});
-
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(ArticleView);
+export default connect(mapStateToProps)(ArticleView);

--- a/src/components/articles/CreateArticlePage.jsx
+++ b/src/components/articles/CreateArticlePage.jsx
@@ -6,46 +6,64 @@ class CreateArticle extends PureComponent {
   render() {
     const {
       handleCreate, handleChangeValue, handleArticleBody, contentArea,
+      imageUpload,
+      titleValue,
+      descriptionValue,
+      tagsValue,
     } = this.props;
     return (
       <div className="container mt-5 createArticle">
         <form id="articleData" className="ml-4" onSubmit={handleCreate}>
           <div>
-            <div>
-              <div>
-                <input
-                  className="articles-text-input"
-                  id="title"
-                  type="text"
-                  required
-                  onChange={handleChangeValue('getTitle')}
-                  placeholder="Title"
-                />
-              </div>
+            <input
+              className="articles-text-input"
+              id="title"
+              type="text"
+              required
+              onChange={handleChangeValue('getTitle')}
+              defaultValue={titleValue}
+              placeholder="Title"
+            />
+          </div>
+          <input
+            className="articles-text-input"
+            id="description"
+            type="text"
+            required
+            onChange={handleChangeValue('getDescription')}
+            defaultValue={descriptionValue}
+            placeholder="Description"
+          />
+          <div className="form-row">
+            <div className="col-7">
               <input
-                className="articles-text-input"
-                id="description"
+                id="tags"
+                onChange={handleChangeValue('getTags')}
                 type="text"
                 required
-                onChange={handleChangeValue('getDescription')}
-                placeholder="Description"
+                defaultValue={tagsValue}
+                placeholder="Tags (,)"
               />
             </div>
-            <div className="form-row">
-              <div className="col-8">
-                <input
-                  id="tags"
-                  onChange={handleChangeValue('getTags')}
-                  type="text"
-                  required
-                  placeholder="Tags (,)"
-                />
-              </div>
-              <Editor required handleArticleBody={handleArticleBody} contentArea={contentArea} />
-            </div>
+            <label
+              className="btn btn-outline-primary btn-file"
+              htmlFor="image"
+            >
+          Add image
+              <input
+                className="file-upload"
+                name="image"
+                onClick={imageUpload}
+                accept=".jpg, .jpeg, .png"
+              />
+            </label>
+            <Editor
+              required
+              handleArticleBody={handleArticleBody}
+              contentArea={contentArea}
+            />
           </div>
         </form>
-
       </div>
     );
   }

--- a/src/components/articles/Tags.jsx
+++ b/src/components/articles/Tags.jsx
@@ -9,6 +9,6 @@ export default ({ tags }) => (
     <FontAwesomeIcon icon="tags" />
     {' '}
 Tags:
-    {tags.map((tag, i) => <a key={i}><span key={i} className="badge badge-info">{tag}</span></a>)}
+    {tags.map((tag, i) => <a key={i}><span key={i} className="badge badge-info space">{tag}</span></a>)}
   </div>
 );

--- a/src/components/articles/__tests__/ArticlesContainerTest.js
+++ b/src/components/articles/__tests__/ArticlesContainerTest.js
@@ -4,7 +4,7 @@ import React from 'react';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
-import { mount } from '../../../__tests__/setup/setupEnzyme';
+import { mount } from 'enzyme';
 import ArticlesContainer, { ArticleView } from '../Articles';
 import { article } from '../../../__mocks__/articleMockData';
 import ArticlePage from '../ArticlePage';
@@ -20,7 +20,10 @@ describe('Articles Container', () => {
     backToHome: jest.fn(),
     singleArticlePage: jest.fn,
     isLoading: jest.fn,
-    article: articles,
+    article,
+    postDataThunk: jest.fn(),
+    getDataThunk: jest.fn(),
+    deleteArticle: jest.fn(),
   };
   beforeEach(() => {
     ArticlePage.prototype.componentDidMount = () => 'Test';
@@ -97,18 +100,37 @@ describe('Articles Container', () => {
     wrapper.find('#title').simulate('change', { target: value });
     expect(instance.handleChangeValue).toBeCalled();
   });
+
+  it('should implement change when inputs receive data', () => {
+    const result = [{ secure_url: 'https://res.cloudinary.com/dos4j4vpc/image/upload/v1547647373/poseidon/cpih2ylhazsnidell5yl.jpg' }];
+    global.cloudinary = {
+      openUploadWidget: (params, cb) => {
+        cb(null, result);
+      },
+    };
+    wrapper.find('.file-upload').simulate('click');
+  });
 });
 
 describe('social share', () => {
   let store;
   const { articles } = article;
   const props = {
-    viewArticle: true,
+    viewArticle: false,
+    backToHome: jest.fn(),
+    singleArticlePage: jest.fn,
+    isLoading: jest.fn,
+    article,
+    postDataThunk: jest.fn(),
+    getDataThunk: jest.fn(),
+    deleteArticle: jest.fn(),
+    
   };
 
   it('handles share email', () => {
     const newProps = {
       ...props,
+      viewArticle: true,
     };
     const mockStore = configureStore([thunk]);
     store = mockStore({ articles: { article: articles } });

--- a/src/components/articles/__tests__/CreateArticlePageTest.js
+++ b/src/components/articles/__tests__/CreateArticlePageTest.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/jsx-filename-extension */
 import React from 'react';
-import { shallow, mount, render } from '../../../__tests__/setup/setupEnzyme';
+import { shallow } from 'enzyme';
 import CreateArticlePage from '../CreateArticlePage';
 import Editor from '../Editor';
 

--- a/src/components/articles/__tests__/EditorTest.js
+++ b/src/components/articles/__tests__/EditorTest.js
@@ -4,9 +4,10 @@ import { shallow, mount, render } from '../../../__tests__/setup/setupEnzyme';
 import Editor from '../Editor';
 
 describe('Editor', () => {
-  let editor, wrapper;
-  let mockCmd = jest.fn();
-  let mockComponentDidMount = jest.fn();
+  let editor;
+  let wrapper;
+  const mockCmd = jest.fn();
+  const mockComponentDidMount = jest.fn();
   const props = {
     handleArticleBody: jest.fn,
     contentArea: ''
@@ -31,12 +32,9 @@ describe('Editor', () => {
 
   it('should trigger createLink onClick event', () => {
     global.document = {
-      execCommand: () => jest.fn()
+      execCommand: () => jest.fn(),
     };
-    wrapper
-      .find('#createLink')
-      .first()
-      .simulate('click');
+    wrapper.find('#createLink').first().simulate('click');
   });
 
   it('should trigger command onClick event', () => {

--- a/src/components/articles/__tests__/TagsTest.js
+++ b/src/components/articles/__tests__/TagsTest.js
@@ -11,6 +11,6 @@ describe('Tags Component', () => {
   });
   it('renders tags array items', () => {
     const wrapper = shallow(<Tags tags={['react', 'redux']} />);
-    expect(wrapper.contains(<span key="0" className="badge badge-info">react</span>)).toBeTruthy();
+    expect(wrapper.contains(<span key="0" className="badge badge-info space">react</span>)).toBeTruthy();
   });
 });

--- a/src/components/articles/__tests__/__snapshots__/EditorTest.js.snap
+++ b/src/components/articles/__tests__/__snapshots__/EditorTest.js.snap
@@ -35375,9 +35375,13 @@ ReactWrapper {
     "adapter": ReactSixteenAdapter {
       "options": Object {
         "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
         "lifecycles": Object {
           "componentDidUpdate": Object {
             "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
           },
           "getDerivedStateFromProps": true,
           "getSnapshotBeforeUpdate": true,

--- a/src/components/articles/articles.scss
+++ b/src/components/articles/articles.scss
@@ -33,6 +33,7 @@
   color: white;
   font-weight: bolder;
 }
+.space{margin-right: 1em}
 
 .articles-text-input:hover {
   border-bottom: 1px solid #3f51b5;
@@ -78,4 +79,18 @@
 .article-img {
   width: 700px;
   height: 300px;
+}
+#imgProfile {
+  width: 100px;
+  height: 100px;
+}
+#central{
+  width: 100%;
+  margin: 0 auto;
+  overflow: hidden;
+  padding: 10px 0;
+  align-items: center;
+  justify-content: space-around;
+  display: flex;
+  float: none;
 }

--- a/src/components/dashboard/ArticleComponent.jsx
+++ b/src/components/dashboard/ArticleComponent.jsx
@@ -7,6 +7,7 @@ import fontawesome from '@fortawesome/fontawesome';
 import solid from '@fortawesome/fontawesome-free-solid';
 import regular from '@fortawesome/fontawesome-free-regular';
 import StarRating from '../../views/rateView';
+import '../articles/articles.scss';
 
 fontawesome.library.add(solid, regular);
 
@@ -14,20 +15,25 @@ const Article = (props) => {
   const getPlainText = data => data.replace(/<(?:.|\n)*?>/gm, '');
 
   const {
-    title, body, author, created_on, image_url, description, slug, average_rating, view_counts,
-  } = props.article;
+    article: {
+      title, body, author, created_on, image_url, description, slug, average_rating, view_counts,
+    },
+    getArticle,
+  } = props;
   return (
-    <div className="jumbotron col-lg-12 col-md-12 article-row">
-      <div className="row">
-        <div className="col-lg-4 col-md-4 col-sm-6 img">
-          <img src={image_url || 'http://placehold.it/350X250'} alt=" " width="350px" height="250px" />
-        </div>
+    <div className="jumbotron col-lg-12 col-md-12 article-row align-self-center">
+      <div className="row justify-content-center">
+        {!image_url ? '' : (
+          <div className="col-lg-4 col-md-4 col-sm-6 img">
+            <img src={ image_url } alt=" " width="350px" height="250px" />
+          </div>
+        )}
         <div className="col-lg-8 col-md-8 col-sm-6">
           <h3 className="title">{title}</h3>
           <hr />
           <h6>{description}</h6>
           <p className="article-body">{getPlainText(body)}</p>
-          <button id="readMore" className="btn btn-primary" onClick={() => props.getArticle(slug)}>Read more</button>
+          <button type="button" id="readMore" className="btn btn-primary" onClick={() => getArticle(slug)}>Read more</button>
           <div className="article-details">
             <i>
               Posted by : &nbsp;
@@ -57,6 +63,7 @@ Article.propTypes = {
     createdAt: PropTypes.string,
     average_rating: PropTypes.number,
   }),
+  getArticle: PropTypes.func.isRequired,
 };
 
 export default Article;

--- a/src/components/dashboard/Dashboard.scss
+++ b/src/components/dashboard/Dashboard.scss
@@ -96,3 +96,4 @@ div.article-row {
   }
   cursor: pointer;
 }
+.tem{justify-content: center;}

--- a/src/components/dashboard/HomeComponent.jsx
+++ b/src/components/dashboard/HomeComponent.jsx
@@ -11,26 +11,49 @@ import TagHeader from '../articles/taggedArticles/pageHeaderComponent';
 class Home extends React.Component {
   render() {
     const {
-      articles, getArticle, getTaggedArticles, tagView, tagName,
+      articles, getArticle, getTaggedArticles, tagView, tagName, getArticlesPage, nextPage,
+      prevPage, currentPage,
     } = this.props;
     const articleList = articles || [];
-    if (tagView) {
-      return (
-        <div className="container-fluid">
-          <div className="row">
-            <TagHeader tagName={tagName}/>
-            <div className="col-lg-10 col-md-10 article-content">
-              {articleList.map(article => (<Article getArticle={getArticle} article={article} key={article.id} />))}
-            </div>
-          </div>
-        </div>
-      );
-    } return (
+    return (
       <div className="container-fluid">
         <div className="row">
-          <SideBar articles={articleList} getTaggedArticles={getTaggedArticles}/>
+          {tagView ? <TagHeader tagName={tagName} />
+            : <SideBar articles={articleList} getTaggedArticles={getTaggedArticles} />}
           <div className="col-lg-10 col-md-10 article-content">
-            {articleList.map(article => (<Article getArticle={getArticle} article={article} key={article.id} />))}
+            {
+              articleList.map(article => (
+                <Article
+                  getArticle={getArticle}
+                  article={article}
+                  key={article.id}
+                />))}
+            <div className="btn-group align-middle">
+              <button
+                type="button"
+                disabled={!prevPage}
+                id="prevPage"
+                className="btn btn-outline-primary"
+                onClick={() => getArticlesPage(`${prevPage}/dgjd`)}
+              >
+                Previous
+              </button>
+              <button
+                type="button"
+                className="btn btn-outline-primary rounded-circle"
+              >
+                {currentPage}
+              </button>
+              <button
+                type="button"
+                disabled={!nextPage}
+                id="nextPage"
+                className="btn btn-outline-primary"
+                onClick={() => getArticlesPage(nextPage)}
+              >
+                Next
+              </button>
+            </div>
           </div>
         </div>
       </div>
@@ -56,9 +79,13 @@ Home.propTypes = {
     }),
   ),
   getArticle: PropTypes.func.isRequired,
+  getArticlesPage: PropTypes.func.isRequired,
   getTaggedArticles: PropTypes.func.isRequired,
   tagView: PropTypes.bool.isRequired,
   tagName: PropTypes.string.isRequired,
+  nextPage: PropTypes.string,
+  prevPage: PropTypes.string,
+  currentPage: PropTypes.number,
 };
 
 Home.defaultProps = {

--- a/src/components/dashboard/NavBarComponent.jsx
+++ b/src/components/dashboard/NavBarComponent.jsx
@@ -4,6 +4,8 @@ import 'popper.js';
 import 'bootstrap/dist/js/bootstrap.bundle.min.js';
 
 const NavBar = (props) => {
+  const token = localStorage.getItem('user');
+  const { createArticle } = props;
   return (
     <div>
       <nav className="navbar navbar-expand-lg navbar-dark">
@@ -14,18 +16,24 @@ const NavBar = (props) => {
 
         <div className="collapse navbar-collapse" id="navbarSupportedContent">
           <ul className="navbar-nav ml-auto my-2 my-lg-0 dropleft">
-            <li className="nav-item dropdown">
-              <a className="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                Profile
-              </a>
-              <div className="dropdown-menu" aria-labelledby="navbarDropdown" data-display="static">
-                <a className="dropdown-item" href="/">Notifications</a>
-                <a className="dropdown-item" href="/profile">View Profile</a>
-                <div className="dropdown-divider" />
-                <a id="newArticle" className="dropdown-item" onClick={props.createArticle}>Create Article</a>
-                <a className="dropdown-item" href="/">Your Articles</a>
-              </div>
-            </li>
+            {
+            !token ? <li><a className="navbar-brand" href="/signup">signIn</a></li>
+              : (
+                <li className="nav-item dropdown">
+                  <a className="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  Profile
+                  </a>
+                  <div className="dropdown-menu" aria-labelledby="navbarDropdown" data-display="static">
+                    <a className="dropdown-item" href="/">Notifications</a>
+                    <a className="dropdown-item" href="/profile">View Profile</a>
+                    <div className="dropdown-divider" />
+                    <a id="newArticle" className="dropdown-item" onClick={createArticle}>Create Article</a>
+                    <a className="dropdown-item" href="/">Your Articles</a>
+                  </div>
+                </li>
+              )
+          }
+
           </ul>
         </div>
       </nav>

--- a/src/components/profile/__tests__/__snapshots__/profileEdit.test.jsx.snap
+++ b/src/components/profile/__tests__/__snapshots__/profileEdit.test.jsx.snap
@@ -8155,9 +8155,13 @@ ReactWrapper {
     "adapter": ReactSixteenAdapter {
       "options": Object {
         "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
         "lifecycles": Object {
           "componentDidUpdate": Object {
             "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
           },
           "getDerivedStateFromProps": true,
           "getSnapshotBeforeUpdate": true,

--- a/src/components/profile/__tests__/__snapshots__/profilePage.test.jsx.snap
+++ b/src/components/profile/__tests__/__snapshots__/profilePage.test.jsx.snap
@@ -4769,9 +4769,13 @@ ReactWrapper {
     "adapter": ReactSixteenAdapter {
       "options": Object {
         "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
         "lifecycles": Object {
           "componentDidUpdate": Object {
             "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
           },
           "getDerivedStateFromProps": true,
           "getSnapshotBeforeUpdate": true,

--- a/src/redux/reducers/ErrorReducer.js
+++ b/src/redux/reducers/ErrorReducer.js
@@ -1,11 +1,12 @@
+import notify from 'msg-notify';
 import * as types from '../actions/types';
 
 export default (state = {}, action) => {
-    switch (action.type) {
-        case types.ERROR_OCCURRED:
-            return { ...state, error: action.errMsg };
+  switch (action.type) {
+    case types.ERROR_OCCURRED:
+      return { ...state, error: action.errMsg };
 
-        default:
-            return state;
-    }
+    default:
+      return state;
+  }
 };

--- a/src/redux/reducers/authentication/index.js
+++ b/src/redux/reducers/authentication/index.js
@@ -17,7 +17,6 @@ const authReducer = (state = initialState, action) => {
     case ACTION_TYPE.SIGN_UP_FAILURE:
       return {
         ...state,
-
         signUpFailure: action.errors,
       };
     default:

--- a/src/redux/thunks/index.js
+++ b/src/redux/thunks/index.js
@@ -26,32 +26,28 @@ const postDataThunkNoHeader = (
     });
 };
 
-const getPrivateDataThunk = (endpoint, actionCreator) => {
-  return (dispatch) => {
-    const token = localStorage.getItem('user');
-    axiosInstance.defaults.headers.common.Authorization = 'Token '.concat(
-      token,
-    );
-    return axiosInstance
-      .get(endpoint)
-      .then((response) => {
-        dispatch(actionCreator(response.data));
-      })
-      .catch((err) => {
-        dispatch(errorOccurred(err));
-      });
-  };
+const getPrivateDataThunk = (endpoint, actionCreator) => (dispatch) => {
+  const token = localStorage.getItem('user');
+  axiosInstance.defaults.headers.common.Authorization = 'Token '.concat(
+    token,
+  );
+  return axiosInstance
+    .get(endpoint)
+    .then((response) => {
+      dispatch(actionCreator(response.data));
+    })
+    .catch((err) => {
+      dispatch(errorOccurred(err));
+    });
 };
 
 export default postDataThunkNoHeader;
 
-const getDataThunk = (endpoint, actionCreator) => {
-  return dispatch =>(
-    axiosInstance.get(endpoint).then((response) => {
-      dispatch(actionCreator(response.data));
-    }).catch(err => dispatch(errorOccurred(err)))
-  );
-};
+const getDataThunk = (endpoint, actionCreator) => dispatch =>(
+  axiosInstance.get(endpoint).then((response) => {
+    dispatch(actionCreator(response.data));
+  }).catch(err => dispatch(errorOccurred(err)))
+);
 
 const postDataThunk = (endpoint, data, actionCreator, method) => (dispatch) => {
   const token = localStorage.getItem('user');
@@ -59,8 +55,11 @@ const postDataThunk = (endpoint, data, actionCreator, method) => (dispatch) => {
   return axiosInstance[method](endpoint, data).then((response) => {
     dispatch(actionCreator(response.data));
   }).catch((err) => {
-    dispatch(errorOccurred(err))});
+    dispatch(errorOccurred(err));
+  });
 };
 
 
-export { getDataThunk, postDataThunk, axiosInstance, getPrivateDataThunk };
+export {
+  getDataThunk, postDataThunk, axiosInstance, getPrivateDataThunk,
+};

--- a/src/routes/index.jsx
+++ b/src/routes/index.jsx
@@ -1,3 +1,4 @@
+/* eslint-disable import/no-named-as-default */
 /* eslint-disable react/prefer-stateless-function */
 import React, { Component } from 'react';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';

--- a/src/views/auth/PasswordResetView.jsx
+++ b/src/views/auth/PasswordResetView.jsx
@@ -19,9 +19,9 @@ class PasswordResetView extends React.Component {
 
     componentWillReceiveProps(nextProps) {
       const { signUpData, errors } = nextProps;
-      signUpData 
-        ? this.redirectOnSuccesfullPasswordReset(signUpData) 
-        : notify(errors.user.detail, 'error')
+      signUpData
+        ? this.redirectOnSuccesfullPasswordReset(signUpData)
+        : notify(errors.user.detail, 'error');
       this.setState({ loader: { loading: false } });
     }
 
@@ -29,19 +29,20 @@ class PasswordResetView extends React.Component {
       if (window.location.href.includes('password-reset')) {
         this.setState({ addNewPassword: false });
         localStorage.setItem('user', this.props.match.params.token);
-      } 
+      }
       else {
         this.setState({ isResetPassword: false });
       }
     }
 
-      redirectOnSuccesfullPasswordReset = nextProps => {
-        notify(nextProps.Message, "success");
-        if (nextProps.Message==="Your password has been updated succesfully") {
-          this.props.history.push("/signup");
-        }}
+      redirectOnSuccesfullPasswordReset = (nextProps) => {
+        notify(nextProps.Message, 'success');
+        if (nextProps.Message === 'Your password has been updated succesfully') {
+          this.props.history.push('/signup');
+        } 
+}
 
-       handleResetSubmit = (e) => { 
+       handleResetSubmit = (e) => {
          e.preventDefault();
          const {
            postDataThunkNoHeader,
@@ -50,7 +51,7 @@ class PasswordResetView extends React.Component {
          } = this.props;
 
          const email = e.target.elements.email.value;
-        
+
          postDataThunkNoHeader('password-reset/', {
            user: {
              email,
@@ -58,10 +59,10 @@ class PasswordResetView extends React.Component {
          }, signUpActionCreatorSuccess, signUpActionCreatorFailure, 'post');
          this.setState({ loader: { loading: true } });
        };
-      
+
        handleNewPasswordSubmit=(e) => {
          e.preventDefault();
-        
+
          const {
            postDataThunk,
            signUpActionCreatorSuccess,
@@ -104,7 +105,7 @@ class PasswordResetView extends React.Component {
             />
           </div>
         );
-      
+
         render() {
           const { isResetPassword, addNewPassword, isSignUp } = this.state;
           const buttonName = !isResetPassword ? 'Send Link' : 'Reset Password';

--- a/src/views/auth/__tests__/authView.test.jsx
+++ b/src/views/auth/__tests__/authView.test.jsx
@@ -19,13 +19,11 @@ const store = mockSTore(expectedStore);
 const mockSignUp = {
   Message: 'Successfully signed up',
   token: '312regwh4tr4hetrj6y5tu6yutu7y8u',
-  Message: 'Successfully signed up',
-  token: '312regwh4tr4hetrj6y5tu6yutu7y8u',
 };
 
 const mockLogin = {
   username: 'naume',
-  token: '312regwh4tr4hetrj6y5tu6yutu7y8u'
+  token: '312regwh4tr4hetrj6y5tu6yutu7y8u',
 };
 const mockError = {
   errors: {
@@ -41,7 +39,7 @@ const mockErrors = {
 
 const errorItems = [
   { title: 'component will recieve props single error', error: mockError },
-  { title: 'component will recieve props multiple error', error: mockErrors }
+  { title: 'component will recieve props multiple error', error: mockErrors },
 ];
 const historyMock = { push: jest.fn() };
 const props = {
@@ -151,9 +149,9 @@ describe(' Chnages isSignUp to false on click', () => {
     target: {
       elements: {
         username: { value: 'poseidon' },
-        password: { value: 'poseidon234' }
-      }
-    }
+        password: { value: 'poseidon234' },
+      },
+    },
   };
   const wrapped = wrapper.find('#change-login');
 
@@ -174,12 +172,11 @@ describe(' Chnages isSignUp to false on click', () => {
     expect(wrapper.find('AuthView').state('loader')).toEqual({
       loading: true,
     });
+  });
+  it('test change to reset password form', () => {
+    wrapper.find('#reset').simulate('click');
+    expect(props.history.push).toHaveBeenCalled();
 
-  })   
-  it('test change to reset password form',()=>{
-    wrapper.find('#reset').simulate('click')
-    expect(props.history.push).toHaveBeenCalled()   
-  
   });
   it('test change to reset password form', () => {
     wrapper.find('#reset').simulate('click');

--- a/src/views/auth/authView.jsx
+++ b/src/views/auth/authView.jsx
@@ -40,7 +40,6 @@ class AuthView extends React.Component {
 
   redirectOnSuccesfullLogin = (nextProps) => {
     const message = nextProps.Message
-      // eslint-disable-next-line no-multi-str
       || 'You have succesfully Logged into Authorz Haven\
     success';
     localStorage.setItem('user', nextProps.token);
@@ -56,10 +55,9 @@ class AuthView extends React.Component {
 
   changeToResetPassword = () => {
     // event.preventDefault()
-    // eslint-disable-next-line react/destructuring-assignment
-    this.props.history.push('/reset-password')
-    ;
-  };
+    this.props.history.push('/reset-password');
+
+};
 
   extractError = (errors) => {
     const errs = Object.keys(errors).map(key => errors[key]);

--- a/src/views/homeView/__tests__/homeViewTest.js
+++ b/src/views/homeView/__tests__/homeViewTest.js
@@ -4,7 +4,7 @@ import configureStore from 'redux-mock-store';
 import { mount } from 'enzyme';
 import { Provider } from 'react-redux';
 import thunk from 'redux-thunk';
-import HomeViewTest from '../homeView';
+import HomeViewTest, { HomeView } from '../homeView';
 import Editor from '../../../components/articles/Editor';
 import mockArticles from '../../../components/dashboard/mockData';
 
@@ -18,18 +18,28 @@ const testClickButton = (wrapper, buttonId, mockMethod) => {
 
 const mockStore = configureStore([thunk]);
 
-let props = {
+const homeProps = {
+  getArticle: jest.fn(),
+  articles: mockArticles,
+  nextPage: 'https://ah-backend-poseidon-staging.herokuapp.com/api/articles?page=2',
+  prevPage: '',
+  currentPage: 1,
+  getArticlesPage: jest.fn()
+};
+
+const props = {
   actions: {
     getOneArticle: jest.fn(),
     getDataThunk: jest.fn(),
+    postDataThunk: jest.fn(),
+    deleteArticle: jest.fn(),
   },
   match: { params: 'none' },
   articles: mockArticles,
-  nextPage: '',
+  nextPage: 'https://ah-backend-poseidon-staging.herokuapp.com/api/articles?page=2',
   prevPage: '',
   currentPage: 1,
-  tagView: false,
-  tagName: '',
+
 };
 describe('Home view test', () => {
   let wrapper;
@@ -42,6 +52,7 @@ describe('Home view test', () => {
         article: mockArticles[1],
       },
     });
+    localStorage.setItem('user', 'usertoken');
     wrapper = mount(<Provider store={store}><HomeViewTest {...props} /></Provider>);
   });
   it('renders without crashing', () => {
@@ -51,7 +62,6 @@ describe('Home view test', () => {
     const event = {
       preventDefault: jest.fn(),
     };
-
     wrapper.find('#newArticle').simulate('click', event);
     jest.runAllTimers();
     expect(wrapper.find('#newArticle')).toBeDefined();
@@ -72,5 +82,10 @@ describe('Home view test', () => {
   it('should handle click event on tag', () => {
     wrapper.find('#tag-name').first().simulate('click');
     expect(wrapper.find('#tag-name')).toBeDefined();
+  });
+  it('should fetch and display next articles (pagination)', () => {
+    wrapper = mount(<HomeView {...props} />);
+    const spy = jest.spyOn(wrapper.instance(), 'getArticlesPage');
+    wrapper.find('#nextPage').simulate('click');
   });
 });

--- a/src/views/homeView/homeView.jsx
+++ b/src/views/homeView/homeView.jsx
@@ -1,16 +1,14 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import * as Actions from '../../redux/thunks';
 import Home from '../../components/dashboard/HomeComponent';
 import NavBar from '../../components/dashboard/NavBarComponent';
 import Articles from '../../components/articles/Articles';
 import {
-  requestArticle,
-  getOneArticle,
-  getAllArticles
+  requestArticle, getOneArticle, getAllArticles, deleteArticle, shareArticle,
 } from '../../redux/actions/ArticleActionCreators';
 import CircularProgressLoader from '../../components/progress/index';
-import { getDataThunk } from '../../redux/thunks';
 
 export class HomeView extends Component {
   state = {
@@ -67,7 +65,12 @@ export class HomeView extends Component {
     this.setState({ loader: { loading: bool } });
   };
 
-  handleClick = tag => e => {
+  getArticlesPage = (url) => {
+    const { actions: { getDataThunk } } = this.props;
+    getDataThunk(url, getAllArticles);
+  }
+
+  handleClick = tag => (e) => {
     e.preventDefault();
     const {
       actions: { getDataThunk }
@@ -80,46 +83,56 @@ export class HomeView extends Component {
   };
 
   render() {
-    const { viewArticle, goToArticles, loader, tagView, tagName } = this.state;
-    const { articles, nextPage, prevPage, currentPage } = this.props;
+    const {
+ viewArticle, goToArticles, loader, tagView, tagName,
+} = this.state;
+    const {
+      articles, nextPage, prevPage, currentPage, actions,
+    } = this.props;
+    const homeProps = {
+      getArticle: this.getArticle,
+      articles,
+      nextPage,
+      prevPage,
+      currentPage,
+      getArticlesPage: this.getArticlesPage,
+      getTaggedArticles: this.handleClick,
+      tagView,
+      tagName,
+    };
+    const articlesProps = {
+      viewArticle,
+      isLoading: this.isLoading,
+      backToHome: this.changeToCreateArticle(false),
+      singleArticlePage: this.singleArticlePage,
+      ...actions,
+    };
     return (
       <div>
         <CircularProgressLoader {...loader} />
         <NavBar createArticle={this.changeToCreateArticle(true)} />
-        {goToArticles ? (
-          <Articles
-            viewArticle={viewArticle}
-            isLoading={this.isLoading}
-            backToHome={this.changeToCreateArticle(false)}
-            singleArticlePage={this.singleArticlePage}
-          />
-        ) : (
-          <Home
-            getArticle={this.getArticle}
-            articles={articles}
-            nextPage={nextPage}
-            prevPage={prevPage}
-            currentPage={currentPage}
-            getTaggedArticles={this.handleClick}
-            tagView={tagView}
-            tagName={tagName}
-          />
-        )}
+        {goToArticles
+          ? <Articles {...articlesProps} /> : <Home {...homeProps} />}
       </div>
     );
   }
 }
+
 const mapStateToProps = ({
-  articles: { articles, nextPage, prevPage, currentPage }
+  articles: {
+    articles, nextPage, prevPage, currentPage,
+  },
 }) => ({
-  articles: articles,
-  nextPage: nextPage,
-  prevPage: prevPage,
-  currentPage: currentPage
+  articles,
+  nextPage,
+  prevPage,
+  currentPage,
 });
 
 const mapDispatchToProps = dispatch => ({
-  actions: bindActionCreators({ getOneArticle, getDataThunk }, dispatch)
+  actions: bindActionCreators({
+    ...Actions, getOneArticle, deleteArticle, shareArticle,
+  }, dispatch),
 });
 
 export default connect(

--- a/src/views/profile/__tests__/__snapshots__/profileEdit.test.jsx.snap
+++ b/src/views/profile/__tests__/__snapshots__/profileEdit.test.jsx.snap
@@ -40,6 +40,7 @@ ShallowWrapper {
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
     "getNode": [Function],
     "render": [Function],
     "simulateError": [Function],
@@ -174,9 +175,13 @@ ShallowWrapper {
     "adapter": ReactSixteenAdapter {
       "options": Object {
         "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
         "lifecycles": Object {
           "componentDidUpdate": Object {
             "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
           },
           "getDerivedStateFromProps": true,
           "getSnapshotBeforeUpdate": true,

--- a/src/views/profile/__tests__/__snapshots__/profileView.test.jsx.snap
+++ b/src/views/profile/__tests__/__snapshots__/profileView.test.jsx.snap
@@ -39,6 +39,7 @@ ShallowWrapper {
   />,
   Symbol(enzyme.__renderer__): Object {
     "batchedUpdates": [Function],
+    "checkPropTypes": [Function],
     "getNode": [Function],
     "render": [Function],
     "simulateError": [Function],
@@ -157,9 +158,13 @@ ShallowWrapper {
     "adapter": ReactSixteenAdapter {
       "options": Object {
         "enableComponentDidUpdateOnSetState": true,
+        "legacyContextMode": "parent",
         "lifecycles": Object {
           "componentDidUpdate": Object {
             "onSetState": true,
+          },
+          "getChildContext": Object {
+            "calledByRenderer": false,
           },
           "getDerivedStateFromProps": true,
           "getSnapshotBeforeUpdate": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -8874,7 +8874,6 @@ react-fontawesome@^1.6.1:
   dependencies:
     prop-types "^15.5.6"
 
-react-is@^16.3.2, react-is@^16.6.3, react-is@^16.7.0:
 react-google-login@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/react-google-login/-/react-google-login-4.0.1.tgz#9aae2d408f264a5808f65ae1e9f07c141214baa7"
@@ -8895,7 +8894,7 @@ react-icons@^2.2.5:
   dependencies:
     react-icon-base "2.1.0"
 
-react-is@^16.3.2, react-is@^16.6.1, react-is@^16.6.3, react-is@^16.7.0:
+react-is@^16.3.2, react-is@^16.6.3, react-is@^16.7.0:
   version "16.7.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.7.0.tgz#c1bd21c64f1f1364c6f70695ec02d69392f41bfa"
   integrity sha512-Z0VRQdF4NPDoI0tsXVMLkJLiwEBa+RP66g0xDHxgxysxSoCUccSten4RTF/UFvZF1dZvZ9Zu1sx+MDXwcOR34g==


### PR DESCRIPTION

**What does this PR do?**
- Implement previous/next page buttons
- Fix the details view for a single article without Images
- Adjust the spacing between **Edit**, **Delete** buttons and **tags**.
- Centralize the details view for a single article
- Write tests

**Description of the tasks to be completed?**
- Add previous, current, and next page buttons on the home component.
- Write a function to fetch articles
- Add css to fix `single article page`
- Write tests

**How to manually test it**
- Clone the repository by running `git clone https://github.com/andela/ah-frontend-poseidon.git`
- Run `git checkout ft-create-articles-162162967`
- Start the server by running `yarn start`
- Click `Previous` or `Next` button when the page finishes loading and you should see different articles and the circle button in the middle changing.
- Click one of the `read more` buttons to view one article

**Screenshots**
<img width="1204" alt="screen shot 2019-01-30 at 5 20 59 pm" src="https://user-images.githubusercontent.com/36928255/51987505-b2dbb580-24b3-11e9-8c04-f3258b2fb3cf.png">
<img width="1440" alt="screen shot 2019-01-29 at 8 17 59 pm" src="https://user-images.githubusercontent.com/36928255/51926754-0b9f4580-2403-11e9-8ec4-198422e4a905.png">



**What are the relevant pivotal tracker stories?**
#162162970